### PR TITLE
Fixed minor issue using the wrong header minor version parser

### DIFF
--- a/isakmp/src/v1/parser/header.rs
+++ b/isakmp/src/v1/parser/header.rs
@@ -16,7 +16,7 @@ pub fn parse_header(buf: &[u8]) -> Result<Header, IsakmpParseError> {
         initiator_cookie: header.initiator_cookie.get(),
         responder_cookie: header.responder_cookie.get(),
         major_version: header.version >> 4,
-        minor_version: header.version << 4,
+        minor_version: header.version & 0b1111,
         flags: header.flags,
         exchange_mode: ExchangeType::try_from(header.exchange_type)?,
         length: header.length.get(),


### PR DESCRIPTION
The minor version is the last 4 bits of the message. It is always set to 0 in the packets, therefore the error did not take any effect yet, but if there were a minor version, it would have created a wrong value here.